### PR TITLE
Sorting

### DIFF
--- a/src/agents/agent.cpp
+++ b/src/agents/agent.cpp
@@ -85,15 +85,16 @@ void Agent::perform_action(Board *pos, SearchLimits* searchLimits, EvalInfo& eva
     set_best_move(evalInfo, pos->total_move_cout());
     cout << evalInfo << endl;
     cout << pos->fen() << endl;
-    if (string(pos->fen()) == string("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR[] b KQkq - 0 1")) {
-        cout << "info string sample move from opening book" << endl;
-        string replies[] = {"e7e5", "e7e5", "e7e5" , "g8f6", "g8f6", "g8f6", "e7e6", "e7e6", "d7d5", "b8c6"};
-        auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
-        srand(unsigned(int(seed)));
-        cout << "bestmove " << replies[seed % 10] << endl;
-    }
-    else {
+    // TODO: Enable opening books in a more proper way
+//    if (string(pos->fen()) == string("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR[] b KQkq - 0 1")) {
+//        cout << "info string sample move from opening book" << endl;
+//        string replies[] = {"e7e5", "e7e5", "e7e5" , "g8f6", "g8f6", "g8f6", "e7e6", "e7e6", "d7d5", "b8c6"};
+//        auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+//        srand(unsigned(int(seed)));
+//        cout << "bestmove " << replies[seed % 10] << endl;
+//    }
+//    else {
         cout << "bestmove " << UCI::move(evalInfo.bestMove, pos->is_chess960()) << endl;
-    }
+//    }
 }
 

--- a/src/agents/config/searchsettings.cpp
+++ b/src/agents/config/searchsettings.cpp
@@ -44,7 +44,11 @@ SearchSettings::SearchSettings():
         qThreshInit(0.5f),
         qThreshMax(0.9f),
         qThreshBase(1965.0f),
-        randomMoveFactor(0.0f)
+        randomMoveFactor(0.0f),
+        threshCheck(0.1f),
+        checkFactor(0.5f),
+        threshCapture(0.1f),
+        captureFactor(0.05f)
 {
 
 }

--- a/src/agents/config/searchsettings.h
+++ b/src/agents/config/searchsettings.h
@@ -55,6 +55,16 @@ struct SearchSettings
     float qThreshBase;
     float randomMoveFactor;
 
+    // adaption of checking and capture moves (currently not as UCI parameters)
+    // Threshold probability for checking moves
+    float threshCheck;
+    // Factor based on the maximum probability with which checks will be increased
+    float checkFactor;
+    // Threshold probability for capture moves
+    float threshCapture;
+    // Factor based on the maximum probability with which captures will be increased
+    float captureFactor;
+
     SearchSettings();
 
 };

--- a/src/agents/mctsagent.cpp
+++ b/src/agents/mctsagent.cpp
@@ -176,7 +176,7 @@ void MCTSAgent::create_new_root_node(Board *pos)
     oldestRootNode = rootNode;
     board_to_planes(pos, 0, true, begin(input_planes));
     netSingle->predict(input_planes, *valueOutput, *probOutputs);
-    fill_nn_results(0, probOutputs, searchSettings, valueOutput, probOutputs, rootNode);
+    fill_nn_results(0, netSingle->is_policy_map(), searchSettings, valueOutput, probOutputs, rootNode);
     rootNode->make_to_root();
     gameNodes.push_back(rootNode);
 }

--- a/src/agents/mctsagent.cpp
+++ b/src/agents/mctsagent.cpp
@@ -277,7 +277,7 @@ void MCTSAgent::print_root_node()
         cout << "info string You must do a search before you can print the root node statistics" << endl;
         return;
     }
-    print_node_statistics(rootNode);
+    rootNode->print_node_statistics();
 }
 
 

--- a/src/agents/mctsagent.cpp
+++ b/src/agents/mctsagent.cpp
@@ -145,7 +145,7 @@ void MCTSAgent::stop_search()
 
 bool MCTSAgent::early_stopping()
 {
-    if (rootNode->first_child_node()->get_prob_value() > 0.9f && rootNode->first_child_node()->get_q_value() > rootNode->second_child_node()->get_q_value()) {
+    if (rootNode->candidate_child_node()->get_prob_value() > 0.9f && rootNode->candidate_child_node()->get_q_value() > rootNode->alternative_child_node()->get_q_value()) {
         cout << "info string Early stopping" << endl;
         return true;
     }
@@ -153,7 +153,7 @@ bool MCTSAgent::early_stopping()
 }
 
 bool MCTSAgent::continue_search() {
-    if (searchLimits->movetime == 0 && searchLimits->movestogo != 1 && rootNode->first_child_node()->get_q_value()+0.1f < lastValueEval) {
+    if (searchLimits->movetime == 0 && searchLimits->movestogo != 1 && rootNode->candidate_child_node()->get_q_value()+0.1f < lastValueEval) {
         cout << "info Increase search time" << endl;
         return true;
     }
@@ -171,7 +171,7 @@ void MCTSAgent::create_new_root_node(Board *pos)
         }
     }
     cout << "info string create new tree" << endl;
-    rootNode = new Node(pos, nullptr, MOVE_NONE);
+    rootNode = new Node(pos, nullptr, MOVE_NONE, searchSettings);
     rootNode->expand();
     oldestRootNode = rootNode;
     board_to_planes(pos, 0, true, begin(input_planes));
@@ -249,7 +249,7 @@ void MCTSAgent::evalute_board_state(Board *pos, EvalInfo& evalInfo)
     lastValueEval = updated_value(rootNode);
     evalInfo.legalMoves = retrieve_legal_moves(rootNode->get_child_nodes());
 //    this->rootNode->get_principal_variation(evalInfo.pv); // TODO
-    evalInfo.pv = {rootNode->first_child_node()->get_move()};
+    evalInfo.pv = {rootNode->candidate_child_node()->get_move()};
     evalInfo.depth = evalInfo.pv.size();
     evalInfo.is_chess960 = pos->is_chess960();
     evalInfo.nodes = rootNode->get_visits();

--- a/src/agents/mctsagent.cpp
+++ b/src/agents/mctsagent.cpp
@@ -108,12 +108,14 @@ Node *MCTSAgent::get_root_node_from_tree(Board *pos)
     if (same_hash_key(ownNextRoot, pos)) {
         delete_sibling_subtrees(ownNextRoot, hashTable);
         delete_sibling_subtrees(opponentsNextRoot, hashTable);
-        ownNextRoot->make_to_root();
+//        cout << "rootNode->get_parent_node()->get_pos()->fen() " << ownNextRoot->get_parent_node()->get_pos()->fen() << endl;
+//        ownNextRoot->make_to_root();
         return ownNextRoot;
     }
     if (same_hash_key(opponentsNextRoot, pos)) {
         delete_sibling_subtrees(opponentsNextRoot, hashTable);
-        opponentsNextRoot->make_to_root();
+//        cout << "rootNode->get_parent_node()->get_pos()->fen() " << opponentsNextRoot->get_parent_node()->get_pos()->fen() << endl;
+//        opponentsNextRoot->make_to_root();
         return opponentsNextRoot;
     }
     return nullptr;
@@ -183,17 +185,16 @@ void MCTSAgent::create_new_root_node(Board *pos)
 void MCTSAgent::apply_move_to_tree(Move move, bool ownMove)
 {
     if (!reusedFullTree) {
+        cout << "info string apply move to tree" << endl;
         if (ownMove) {
             opponentsNextRoot = pick_next_node(move, rootNode);
-            if (opponentsNextRoot != nullptr && opponentsNextRoot->has_nn_results()) {
-                cout << "info string apply move to tree" << endl;
+            if (opponentsNextRoot != nullptr) { // && opponentsNextRoot->has_nn_results()) {
                 gameNodes.push_back(opponentsNextRoot);
             }
         }
         else {
             ownNextRoot = pick_next_node(move, opponentsNextRoot);
-            if (ownNextRoot != nullptr && ownNextRoot->has_nn_results()) {
-                cout << "info string apply move to tree" << endl;
+            if (ownNextRoot != nullptr) { // && ownNextRoot->has_nn_results()) {
                 gameNodes.push_back(ownNextRoot);
             }
         }
@@ -228,6 +229,14 @@ void MCTSAgent::evalute_board_state(Board *pos, EvalInfo& evalInfo)
     else {
         cout << "info string apply dirichlet" << endl;
         rootNode->apply_dirichlet_noise_to_prior_policy();
+        if (rootNode->get_parent_node() == nullptr) {
+            rootNode->sort_child_nodes_by_probabilities();
+        }
+        else {
+            rootNode->sort_child_nodes_by_q_plus_u();
+            rootNode->mark_as_uncalibrated();
+            rootNode->make_to_root();
+        }
         run_mcts_search();
     }
 

--- a/src/agents/mctsagent.cpp
+++ b/src/agents/mctsagent.cpp
@@ -99,7 +99,6 @@ Node *MCTSAgent::get_root_node_from_tree(Board *pos)
     if (rootNode == nullptr) {
         return nullptr;
     }
-
     if (same_hash_key(rootNode, pos)) {
         cout << "info string reuse the full tree" << endl;
         reusedFullTree = true;
@@ -171,13 +170,12 @@ void MCTSAgent::create_new_root_node(Board *pos)
         }
     }
     cout << "info string create new tree" << endl;
-    rootNode = new Node(pos, nullptr, MOVE_NONE, searchSettings);
+    rootNode = new Node(newPos, nullptr, MOVE_NONE, searchSettings);
     rootNode->expand();
     oldestRootNode = rootNode;
     board_to_planes(pos, 0, true, begin(input_planes));
     netSingle->predict(input_planes, *valueOutput, *probOutputs);
     fill_nn_results(0, netSingle->is_policy_map(), searchSettings, valueOutput, probOutputs, rootNode);
-    rootNode->make_to_root();
     gameNodes.push_back(rootNode);
 }
 
@@ -245,8 +243,8 @@ void MCTSAgent::evalute_board_state(Board *pos, EvalInfo& evalInfo)
 //    if (bestIdx != argmax(rootNode->childNumberVisits)) {
 //        cout << "info string Select different move due to higher Q-value" << endl;
 //    }
-    evalInfo.centipawns = value_to_centipawn(updated_value(rootNode));
-    lastValueEval = updated_value(rootNode);
+    lastValueEval = updated_value(rootNode, evalInfo.policyProbSmall);
+    evalInfo.centipawns = value_to_centipawn(lastValueEval);
     evalInfo.legalMoves = retrieve_legal_moves(rootNode->get_child_nodes());
     get_principal_variation(rootNode, searchSettings, evalInfo.pv);
     evalInfo.depth = evalInfo.pv.size();

--- a/src/agents/mctsagent.cpp
+++ b/src/agents/mctsagent.cpp
@@ -228,8 +228,8 @@ void MCTSAgent::evalute_board_state(Board *pos, EvalInfo& evalInfo)
         cout << "info string The given position has no legal moves" << endl;
     }
     else {
-        cout << "info string apply dirichlet TODO" << endl;
-//        rootNode->apply_dirichlet_noise_to_prior_policy();
+        cout << "info string apply dirichlet" << endl;
+        rootNode->apply_dirichlet_noise_to_prior_policy();
         run_mcts_search();
     }
 

--- a/src/agents/mctsagent.cpp
+++ b/src/agents/mctsagent.cpp
@@ -277,7 +277,7 @@ void MCTSAgent::print_root_node()
         cout << "info string You must do a search before you can print the root node statistics" << endl;
         return;
     }
-    rootNode->print_node_statistics();
+    print_node_statistics(rootNode);
 }
 
 

--- a/src/agents/mctsagent.cpp
+++ b/src/agents/mctsagent.cpp
@@ -241,15 +241,14 @@ void MCTSAgent::evalute_board_state(Board *pos, EvalInfo& evalInfo)
     get_mcts_policy(rootNode, searchSettings->qValueWeight,
                     get_current_q_thresh(searchSettings, rootNode->get_visits()),
                     evalInfo.policyProbSmall);
-    size_t bestIdx = argmax(evalInfo.policyProbSmall);
+//    size_t bestIdx = argmax(evalInfo.policyProbSmall);
 //    if (bestIdx != argmax(rootNode->childNumberVisits)) {
 //        cout << "info string Select different move due to higher Q-value" << endl;
 //    }
     evalInfo.centipawns = value_to_centipawn(updated_value(rootNode));
     lastValueEval = updated_value(rootNode);
     evalInfo.legalMoves = retrieve_legal_moves(rootNode->get_child_nodes());
-//    this->rootNode->get_principal_variation(evalInfo.pv); // TODO
-    evalInfo.pv = {rootNode->candidate_child_node()->get_move()};
+    get_principal_variation(rootNode, searchSettings, evalInfo.pv);
     evalInfo.depth = evalInfo.pv.size();
     evalInfo.is_chess960 = pos->is_chess960();
     evalInfo.nodes = rootNode->get_visits();

--- a/src/agents/rawnetagent.cpp
+++ b/src/agents/rawnetagent.cpp
@@ -82,7 +82,7 @@ void RawNetAgent::evalute_board_state(Board *pos, EvalInfo& evalInfo)
 
     evalInfo.policyProbSmall.resize(evalInfo.legalMoves.size());
     get_probs_of_move_list(0, &probOutputs, evalInfo.legalMoves, pos->side_to_move(),
-                           !net->getSelectPolicyFromPlane(), evalInfo.policyProbSmall, net->getSelectPolicyFromPlane());
+                           !net->is_policy_map(), evalInfo.policyProbSmall, net->is_policy_map());
     size_t sel_idx = argmax(evalInfo.policyProbSmall);
 
     Move bestmove = evalInfo.legalMoves[sel_idx];

--- a/src/crazyara.cpp
+++ b/src/crazyara.cpp
@@ -271,36 +271,13 @@ void CrazyAra::init()
     Position::init();
     Bitbases::init();
     Search::init();
-    Constants::init();
 }
 
 bool CrazyAra::is_ready()
 {
     if (!networkLoaded) {
-        searchSettings = new SearchSettings();
-        searchSettings->threads = Options["Threads"];
-        searchSettings->batchSize = Options["Batch_Size"];
-        searchSettings->useTranspositionTable = Options["Use_Transposition_Table"];
-        searchSettings->uInit = float(Options["Centi_U_Init_Divisor"]) / 100.0f;
-        searchSettings->uMin = Options["Centi_U_Min"] / 100.0f;
-        searchSettings->uBase = Options["U_Base"];
-        searchSettings->qValueWeight = Options["Centi_Q_Value_Weight"] / 100.0f;
-        searchSettings->enhanceChecks = Options["Enhance_Checks"];
-        searchSettings->enhanceCaptures = Options["Enhance_Captures"];
-        searchSettings->cpuctInit = Options["Centi_CPuct_Init"] / 100.0f;
-        searchSettings->cpuctBase = Options["CPuct_Base"];
-        searchSettings->dirichletEpsilon = Options["Centi_Dirichlet_Epsilon"] / 100.0f;
-        searchSettings->dirichletAlpha = Options["Centi_Dirichlet_Alpha"] / 100.0f;
-        searchSettings->virtualLoss = Options["Virtual_Loss"];
-        searchSettings->qThreshInit = Options["Centi_Q_Thresh_Init"] / 100.0f;
-        searchSettings->qThreshMax = Options["Centi_Q_Thresh_Max"] / 100.0f;
-        searchSettings->qThreshBase = Options["Q_Thresh_Base"];
-        searchSettings->randomMoveFactor = Options["Centi_Random_Move_Factor"]  / 100.0f;
-
-        playSettings = new PlaySettings();
-        playSettings->temperature = Options["Centi_Temperature"] / 100.0f;
-        playSettings->temperatureMoves = Options["Temperature_Moves"];
-
+        init_search_settings();
+        init_play_settings();
         string modelDirectory = Options["Model_Directory"];
         netSingle = new NeuralNetAPI(Options["Context"], 1, modelDirectory);
         rawAgent = new RawNetAgent(netSingle, PlaySettings(), 0, 0, true);
@@ -308,6 +285,7 @@ bool CrazyAra::is_ready()
         for (size_t i = 0; i < searchSettings->threads; ++i) {
             netBatches[i] = new NeuralNetAPI(Options["Context"], searchSettings->batchSize, modelDirectory);
         }
+        Constants::init(netSingle->is_policy_map());
         mctsAgent = new MCTSAgent(netSingle, netBatches, searchSettings, *playSettings, states);
         networkLoaded = true;
     }
@@ -326,4 +304,34 @@ string CrazyAra::engine_info()
     ss << "id name " << name << " " << version << " (" << __DATE__ << ")" << "\n";
     ss << "id author " << authors;
     return ss.str();
+}
+
+void CrazyAra::init_search_settings()
+{
+    searchSettings = new SearchSettings();
+    searchSettings->threads = Options["Threads"];
+    searchSettings->batchSize = Options["Batch_Size"];
+    searchSettings->useTranspositionTable = Options["Use_Transposition_Table"];
+    searchSettings->uInit = float(Options["Centi_U_Init_Divisor"]) / 100.0f;
+    searchSettings->uMin = Options["Centi_U_Min"] / 100.0f;
+    searchSettings->uBase = Options["U_Base"];
+    searchSettings->qValueWeight = Options["Centi_Q_Value_Weight"] / 100.0f;
+    searchSettings->enhanceChecks = Options["Enhance_Checks"];
+    searchSettings->enhanceCaptures = Options["Enhance_Captures"];
+    searchSettings->cpuctInit = Options["Centi_CPuct_Init"] / 100.0f;
+    searchSettings->cpuctBase = Options["CPuct_Base"];
+    searchSettings->dirichletEpsilon = Options["Centi_Dirichlet_Epsilon"] / 100.0f;
+    searchSettings->dirichletAlpha = Options["Centi_Dirichlet_Alpha"] / 100.0f;
+    searchSettings->virtualLoss = Options["Virtual_Loss"];
+    searchSettings->qThreshInit = Options["Centi_Q_Thresh_Init"] / 100.0f;
+    searchSettings->qThreshMax = Options["Centi_Q_Thresh_Max"] / 100.0f;
+    searchSettings->qThreshBase = Options["Q_Thresh_Base"];
+    searchSettings->randomMoveFactor = Options["Centi_Random_Move_Factor"]  / 100.0f;
+}
+
+void CrazyAra::init_play_settings()
+{
+    playSettings = new PlaySettings();
+    playSettings->temperature = Options["Centi_Temperature"] / 100.0f;
+    playSettings->temperatureMoves = Options["Temperature_Moves"];
 }

--- a/src/crazyara.h
+++ b/src/crazyara.h
@@ -118,7 +118,7 @@ public:
      * @param evalInfo Returns the evalutation information
      * @param applyMoveToTree Tells if the given move shall be applied to the tree for future reusage
      */
-    void go(Board *pos, istringstream& is, EvalInfo& evalInfo, bool applyMoveToTree=true);
+    void go(Board* pos, istringstream& is, EvalInfo& evalInfo, bool applyMoveToTree=true);
 
     /**
      * @brief go Wrapper function for go() which accepts a FEN string
@@ -134,13 +134,13 @@ public:
      * @param pos Position object which will be set
      * @param is List of command line arguments which describe the position
      */
-    void position(Board *pos, istringstream &is);
+    void position(Board* pos, istringstream& is);
 
     /**
      * @brief benchmark Runs a list of benchmark position for a given time
      * @param is Movetime in ms
      */
-    void benchmark(istringstream &is);
+    void benchmark(istringstream& is);
 
     /**
      * @brief init_search_settings Initializes the search settings with the current UCI parameters

--- a/src/crazyara.h
+++ b/src/crazyara.h
@@ -141,6 +141,16 @@ public:
      * @param is Movetime in ms
      */
     void benchmark(istringstream &is);
+
+    /**
+     * @brief init_search_settings Initializes the search settings with the current UCI parameters
+     */
+    void init_search_settings();
+
+    /**
+     * @brief init_play_settings Initializes the play settings with the current UCI parameters
+     */
+    void init_play_settings();
 };
 
 #endif // CRAZYARA_H

--- a/src/domain/crazyhouse/constants.h
+++ b/src/domain/crazyhouse/constants.h
@@ -39,6 +39,7 @@
 #include "types.h"
 #include "../../util/sfutil.h"
 #include <iostream>
+#include "policymaprepresentation.h"
 
 // Define the board size
 const int BOARD_WIDTH = 8;
@@ -2367,18 +2368,18 @@ extern std::string LABELS_MIRRORED[NB_LABELS];
 std::string mirror_move(std::string moveUCI);
 
 namespace Constants {
-inline void init() {
+inline void init(bool isPolicyMap) {
 
     // fill mirrored label list and look-up table
     for (size_t mvIdx=0; mvIdx < NB_LABELS; mvIdx++) {
         LABELS_MIRRORED[mvIdx] = mirror_move(LABELS[mvIdx]);
         std::vector<Move> moves = make_move(LABELS[mvIdx]);
         for (Move move : moves) {
-            MV_LOOKUP.insert({move, mvIdx});
+            isPolicyMap ? MV_LOOKUP.insert({move, FLAT_PLANE_IDX[mvIdx]}) : MV_LOOKUP.insert({move, mvIdx});
         }
         std::vector<Move> moves_mirrored = make_move(LABELS_MIRRORED[mvIdx]);
         for (Move move : moves_mirrored) {
-            MV_LOOKUP_MIRRORED.insert({move, mvIdx});
+            isPolicyMap ? MV_LOOKUP_MIRRORED.insert({move, FLAT_PLANE_IDX[mvIdx]}) : MV_LOOKUP_MIRRORED.insert({move, mvIdx});
         }
     }
 }

--- a/src/domain/crazyhouse/inputrepresentation.h
+++ b/src/domain/crazyhouse/inputrepresentation.h
@@ -31,7 +31,7 @@
 #include "../../board.h"
 
 /**
- * @brief board_to_planes Converts the given board represetntation into the plane representation.
+ * @brief board_to_planes Converts the given board representation into the plane representation.
  *                        The plane representation will be encoded on a flat float array.
  *                        No history and only the single current board position will be encoded.
  * @param pos Board position

--- a/src/domain/crazyhouse/outputrepresentation.h
+++ b/src/domain/crazyhouse/outputrepresentation.h
@@ -37,6 +37,24 @@ using blaze::HybridVector;
 using blaze::DynamicVector;
 
 using namespace mxnet::cpp;
+using namespace std;
+
+
+/**
+ * @brief get_policy_data_batch Returns the pointer of the batch for the policy predictions
+ * @param batchIdx Batch index for the current predicion
+ * @param policyProb All policy predicitons from the batch
+ * @param isPolicyMap Sets if the policy is encoded in policy map representation
+ * @return Starting pointer for predictions of the current batch
+ */
+const float*  get_policy_data_batch(const size_t batchIdx, const NDArray* policyProb, bool isPolicyMap);
+
+/**
+ * @brief get_current_move_lookup Returns the look-up table to use depending on the side to move
+ * @param sideToMove Current side to move
+ * @return Returns either MOVE_LOOK_UP or MOVE_LOOK_UP_MIRRORED
+ */
+unordered_map<Move, size_t>& get_current_move_lookup(Color sideToMove);
 
 /**
  * @brief get_probs_of_move_list Returns an array in which entry relates to the probability for the given move list.
@@ -53,11 +71,16 @@ using namespace mxnet::cpp;
 void get_probs_of_move_list(const size_t batchIdx, const NDArray* policyProb, const std::vector<Move> &legalMoves, Color sideToMove,
                             bool normalize, DynamicVector<float> &policyProbSmall, bool select_policy_from_plance);
 
+void get_probs_of_moves(const float *data, const vector<Move>& legalMoves,
+                        unordered_map<Move, size_t>& moveLookup, DynamicVector<float> &policyProbSmall);
+
 /**
  * @brief value_to_centipawn Converts a value in A0-notation to roughly a centi-pawn loss
  * @param value floating value from [-1.,1.]
  * @return Returns centipawn conversion for value
  */
 int value_to_centipawn(float value);
+
+void apply_softmax(DynamicVector<float> &policyProbSmall);
 
 #endif // OUTPUTREPRESENTATION_H

--- a/src/domain/crazyhouse/policymaprepresentation.h
+++ b/src/domain/crazyhouse/policymaprepresentation.h
@@ -30,7 +30,6 @@
 #ifndef POLICYMAPREPRESENTATION_H
 #define POLICYMAPREPRESENTATION_H
 
-
 // generated conversion list which describes the plane index for each move in the policy LABELS list using the python script at:
 // https://github.com/QueensGambit/CrazyAra/blob/master/DeepCrazyhouse/src/domain/crazyhouse/plane_policy_representation.py
 const unsigned long FLAT_PLANE_IDX[] = {

--- a/src/manager/treemanager.cpp
+++ b/src/manager/treemanager.cpp
@@ -31,9 +31,11 @@
 
 Node* pick_next_node(Move move, const Node* parentNode)
 {
-    for (Node* node : parentNode->get_child_nodes()) {
-        if (node->get_move() == move) {
-            return node;
+    if (parentNode != nullptr) {
+        for (Node* node : parentNode->get_child_nodes()) {
+            if (node->get_move() == move) {
+                return node;
+            }
         }
     }
     return nullptr;

--- a/src/manager/treemanager.cpp
+++ b/src/manager/treemanager.cpp
@@ -33,7 +33,10 @@ Node* pick_next_node(Move move, const Node* parentNode)
 {
     if (parentNode != nullptr) {
         for (Node* node : parentNode->get_child_nodes()) {
-            if (node->get_move() == move) {
+            if (node->get_move() == move && node->is_expanded()) {
+//                if (!node->is_expanded()) {
+//                    node->expand();
+//                }
                 return node;
             }
         }

--- a/src/manager/treemanager.cpp
+++ b/src/manager/treemanager.cpp
@@ -29,12 +29,11 @@
 #include "misc.h"
 #include "../node.h"
 
-Node* pick_next_node(Move move, Node* parentNode)
+Node* pick_next_node(Move move, const Node* parentNode)
 {
-    if (parentNode != nullptr) {
-        int foundIdx = parentNode->find_move_idx(move);
-        if (foundIdx != -1 && parentNode->get_child_node(size_t(foundIdx)) != nullptr) {
-            return parentNode->get_child_node(size_t(foundIdx));
+    for (Node* node : parentNode->get_child_nodes()) {
+        if (node->get_move() == move) {
+            return node;
         }
     }
     return nullptr;

--- a/src/manager/treemanager.h
+++ b/src/manager/treemanager.h
@@ -37,7 +37,7 @@
  * @param move Move
  * @param ownMove Boolean indicating if it was CrazyAra's move
  */
-Node* pick_next_node(Move move, Node* parentNode);
+Node* pick_next_node(Move move, const Node* parentNode);
 
 /**
  * @brief same_hash_key Checks if the given node isn't a nullptr and share the same hash key as the position

--- a/src/nn/neuralnetapi.cpp
+++ b/src/nn/neuralnetapi.cpp
@@ -84,12 +84,12 @@ NeuralNetAPI::NeuralNetAPI(const string& ctx, unsigned int batchSize, const stri
     load_model(jsonFilePath);
     load_parameters(paramterFilePath);
     bind_executor();
-    infer_select_policy_from_planes();
+    check_if_policy_map();
 }
 
-bool NeuralNetAPI::getSelectPolicyFromPlane() const
+bool NeuralNetAPI::is_policy_map() const
 {
-    return selectPolicyFromPlane;
+    return isPolicyMap;
 }
 
 bool NeuralNetAPI::file_exists(const string &name)
@@ -156,15 +156,15 @@ void NeuralNetAPI::bind_executor()
 	cout << "info string Bind successfull!" << endl;
 }
 
-void NeuralNetAPI::infer_select_policy_from_planes()
+void NeuralNetAPI::check_if_policy_map()
 {
     float* inputPlanes = new float[batchSize*NB_VALUES_TOTAL];
     fill(inputPlanes, inputPlanes+batchSize*NB_VALUES_TOTAL, 0.0f);
 
     float value;
     NDArray probOutputs = predict(inputPlanes, value);
-    selectPolicyFromPlane = probOutputs.GetShape()[1] != NB_LABELS;
-	cout << "info string selectPolicyFromPlane: " << selectPolicyFromPlane << endl;
+    isPolicyMap = probOutputs.GetShape()[1] != NB_LABELS;
+    cout << "info string selectPolicyFromPlane: " << isPolicyMap << endl;
 	delete inputPlanes;
 }
 

--- a/src/nn/neuralnetapi.cpp
+++ b/src/nn/neuralnetapi.cpp
@@ -164,8 +164,8 @@ void NeuralNetAPI::check_if_policy_map()
     float value;
     NDArray probOutputs = predict(inputPlanes, value);
     isPolicyMap = probOutputs.GetShape()[1] != NB_LABELS;
-    cout << "info string selectPolicyFromPlane: " << isPolicyMap << endl;
-	delete inputPlanes;
+    cout << "info string isPolicyMap: " << isPolicyMap << endl;
+    delete[] inputPlanes;
 }
 
 NDArray NeuralNetAPI::predict(float *inputPlanes, float &value)

--- a/src/nn/neuralnetapi.h
+++ b/src/nn/neuralnetapi.h
@@ -51,6 +51,7 @@ private:
     Context globalCtx = Context::cpu();
     unsigned int batchSize;
     bool isPolicyMap;
+    bool enableTensorrt;
 
     /**
      * @brief FileExists Function to check if a file exists in a given path
@@ -81,6 +82,28 @@ private:
      * and sets the selectPolicyFromPlane boolean accordingly
      */
     void check_if_policy_map();
+
+    /**
+     * @brief SplitParamMap Splits loaded param map into arg parm and aux param with target context
+     * @param paramMap Parameter map
+     * @param argParamInTargetContext Output intermediate parameter map
+     * @param auxParamInTargetContext Output intermediate auxiliary map
+     * @param targetContext Computation context e.g. Context::cpu(), Context::gpu()
+     */
+    void SplitParamMap(const std::map<std::string, NDArray> &paramMap,
+        std::map<std::string, NDArray> *argParamInTargetContext,
+        std::map<std::string, NDArray> *auxParamInTargetContext,
+        Context targetContext);
+
+    /**
+     * @brief ConvertParamMapToTargetContext Copies the param map into the target context
+     * @param paramMap Parameter map
+     * @param paramMapInTargetContext Output parameter map
+     * @param targetContext Computation context e.g. Context::cpu(), Context::gpu()
+     */
+    void ConvertParamMapToTargetContext(const std::map<std::string, NDArray> &paramMap,
+        std::map<std::string, NDArray> *paramMapInTargetContext,
+        Context targetContext);
 
 public:
     /**

--- a/src/nn/neuralnetapi.h
+++ b/src/nn/neuralnetapi.h
@@ -50,7 +50,7 @@ private:
     Shape inputShape;
     Context globalCtx = Context::cpu();
     unsigned int batchSize;
-    bool selectPolicyFromPlane;
+    bool isPolicyMap;
 
     /**
      * @brief FileExists Function to check if a file exists in a given path
@@ -80,7 +80,7 @@ private:
      * @brief infer_select_policy_from_planes Checks if the loaded model encodes the policy as planes
      * and sets the selectPolicyFromPlane boolean accordingly
      */
-    void infer_select_policy_from_planes();
+    void check_if_policy_map();
 
 public:
     /**
@@ -108,7 +108,7 @@ public:
      */
     void predict(float *inputPlanes, NDArray &valueOutput, NDArray &probOutputs);
 
-    bool getSelectPolicyFromPlane() const;
+    bool is_policy_map() const;
 };
 
 #endif // NEURALNETAPI_H

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -547,7 +547,7 @@ void delete_sibling_subtrees(Node* node, unordered_map<Key, Node*>* hashTable)
     }
 }
 
-void delete_subtree_and_hash_entries(Node *node, unordered_map<Key, Node*>* hashTable)
+void delete_subtree_and_hash_entries(Node* node, unordered_map<Key, Node*>* hashTable)
 {
     for (Node* childNode: node->get_child_nodes()) {
         if (childNode != nullptr) {
@@ -562,7 +562,7 @@ void delete_subtree_and_hash_entries(Node *node, unordered_map<Key, Node*>* hash
     delete node;
 }
 
-void get_mcts_policy(const Node *node, const float qValueWeight, const float qThresh, DynamicVector<float> &mctsPolicy)
+void get_mcts_policy(const Node *node, const float qValueWeight, const float qThresh, DynamicVector<float>& mctsPolicy)
 {
     DynamicVector<float> childNumberVisits = retrieve_visits(node);
     if (qValueWeight > 0) {
@@ -581,7 +581,7 @@ void get_mcts_policy(const Node *node, const float qValueWeight, const float qTh
     }
 }
 
-DynamicVector<float> retrieve_dynamic_vector(const vector<Node *> &childNodes, vFunctionValue func)
+DynamicVector<float> retrieve_dynamic_vector(const vector<Node *>& childNodes, vFunctionValue func)
 {
     DynamicVector<float> values(childNodes.size());
     for (size_t i = 0; i < childNodes.size(); ++i) {
@@ -590,12 +590,12 @@ DynamicVector<float> retrieve_dynamic_vector(const vector<Node *> &childNodes, v
     return values;
 }
 
-float get_visits(Node *node)
+float get_visits(Node* node)
 {
     return node->get_visits();
 }
 
-float get_q_value(Node *node)
+float get_q_value(Node* node)
 {
     return node->get_q_value();
 }
@@ -610,7 +610,7 @@ DynamicVector<float> retrieve_q_values(const Node* node)
     return retrieve_dynamic_vector(node->get_child_nodes(), get_q_value);
 }
 
- float get_current_q_thresh(SearchSettings* searchSettings, int numberVisits)
+ float get_current_q_thresh(const SearchSettings* searchSettings, int numberVisits)
 {
     return searchSettings->qThreshMax - exp(-numberVisits / searchSettings->qThreshBase) * (searchSettings->qThreshMax - searchSettings->qThreshInit);
 }
@@ -661,4 +661,20 @@ bool prob_value_comparision(const Node* n1, const Node* n2)
 bool q_plus_u_comparision(const Node* n1, const Node* n2)
 {
     return n1->get_q_plus_u() > n2->get_q_plus_u();
+}
+
+void get_principal_variation(const Node* rootNode, const SearchSettings* searchSettings, vector<Move>& pv)
+{
+    pv.clear();
+    const Node* curNode = rootNode;
+    size_t childIdx;
+    do {
+        DynamicVector<float> mctsPolicy(curNode->get_number_child_nodes());
+        get_mcts_policy(curNode, searchSettings->qValueWeight,
+                        get_current_q_thresh(searchSettings, int(rootNode->get_visits())),
+                        mctsPolicy);
+        childIdx = argmax(mctsPolicy);
+        pv.push_back(curNode->get_child_nodes()[childIdx]->get_move());
+        curNode = curNode->get_child_nodes()[childIdx];
+    } while (curNode->is_expanded() && !curNode->is_terminal());
 }

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -506,6 +506,7 @@ void enhance_moves(const SearchSettings* searchSettings, const Board* pos, const
 
 Node* select_child_node(Node* node)
 {
+    node->lock();
     node->update_u_divisor();
     node->update_u_parent_factor();
     if (node->is_calibrated()) {
@@ -519,6 +520,7 @@ Node* select_child_node(Node* node)
             node->sort_child_nodes_by_probabilities();
         }
     }
+    node->unlock();
     return node->candidate_child_node();
 }
 

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -51,6 +51,28 @@ Node::Node(Board *pos, Node *parentNode, Move move,  SearchSettings* searchSetti
     this->pos = pos;
 }
 
+void Node::operator=(const Node& b)
+{
+    value = b.value;
+    pos = b.pos;
+    numberChildNodes = b.numberChildNodes;
+    // copy the probability values for all child nodes
+    for (Node* node : b.childNodes) {
+        Node* newChild = new Node(this, node->move, node->searchSettings);
+        newChild->probValue = node->probValue;
+        childNodes.push_back(newChild);
+    }
+    isTerminal = b.isTerminal;
+    value = b.value;
+    visits = 1;
+    childNodes.resize(numberChildNodes);
+    //    parentNode = // is not copied
+    hasNNResults = b.hasNNResults;
+    searchSettings = b.searchSettings;
+    isTerminal = b.isTerminal;
+    isExpanded = true;
+}
+
 void Node::sort_child_nodes_by_probabilities()
 {
     sort(childNodes.begin(), childNodes.end(), prob_value_comparision);

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -88,8 +88,15 @@ void Node::sort_child_nodes_by_probabilities()
     sort(childNodes.begin(), childNodes.end(), prob_value_comparision);
 
     areChildNodesSorted = true;
-    isCalibrated = true; //true; // !
-    nodeIdxUpdate = 1;
+    isCalibrated = true;
+    nodeIdxUpdate = 2; //2;
+}
+
+void Node::sort_child_nodes_by_q_plus_u()
+{
+    sort(childNodes.begin(), childNodes.end(), q_plus_u_comparision);
+    areChildNodesSorted = true;
+    isCalibrated = true;
 }
 
 void Node::calibrate_child_node_order()
@@ -102,16 +109,19 @@ void Node::calibrate_child_node_order()
 //            [=](const Node* n1, const Node* n2) {
 //            return n1->get_q_plus_u() > n2->get_q_plus_u();
 //        });
-        std::sort(childNodes.begin(), childNodes.begin()+int(nodeIdxUpdate), q_plus_u_comparision);
+//        std::sort(childNodes.begin(), childNodes.begin()+int(nodeIdxUpdate), q_plus_u_comparision);
 //    }
+    partial_sort(childNodes.begin(), childNodes.begin()+1, childNodes.end(), q_plus_u_comparision);
+
     // sorting
     areChildNodesSorted = true;
     isCalibrated = true;
 
     // DEBUG
 //    if (!is_ordering_correct(childNodes)) {
+//        cout << "nodeIdxUpdate: " << nodeIdxUpdate << endl;
 //        print_node_statistics(this);
-    assert(is_ordering_correct(childNodes));
+        assert(is_ordering_correct(childNodes));
 //    }
 //    nodeIdxUpdate = 1;
 //    nodeIdxUpdate = 0;
@@ -346,9 +356,6 @@ void Node::check_for_terminal()
         // normal game position
         isTerminal = false;
     }
-    if (isTerminal) {
-        cout << "terminal" << endl;
-    }
 }
 
 void Node::make_to_root()
@@ -376,7 +383,7 @@ void Node::revert_virtual_loss_and_update(float value)
 void Node::init_board()
 {
     StateInfo* newState = new StateInfo;
-    pos = new Board(*parentNode->get_pos());
+    pos = new Board(*parentNode->pos);
     pos->do_move(move, *newState);
 }
 
@@ -655,8 +662,8 @@ void print_node_statistics(Node* node)
 
 bool is_ordering_correct(vector<Node*> &childNodes)
 {
-    for (size_t i = 0; i < childNodes.size()-1; ++i) {
-        if (childNodes[i]->get_q_plus_u() < childNodes[i+1]->get_q_plus_u()) {
+    for (size_t i = 0; i < childNodes.size(); ++i) {
+        if (childNodes[0]->get_q_plus_u() < childNodes[i]->get_q_plus_u()) {
             return false;
         }
     }

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -24,6 +24,7 @@
  */
 
 #include "node.h"
+#include "util/blazeutil.h" // get_dirichlet_noise()
 
 Node::Node(Node *parentNode, Move move,  SearchSettings* searchSettings):
     parentNode(parentNode),
@@ -413,6 +414,16 @@ void Node::unlock()
 void Node::mark_as_uncalibrated()
 {
     isCalibrated = false;
+}
+
+void Node::apply_dirichlet_noise_to_prior_policy()
+{
+    DynamicVector<float> dirichletNoise = get_dirichlet_noise(numberChildNodes, searchSettings->dirichletAlpha);
+    size_t idx = 0;
+    float probEpsilon = (1 - searchSettings->dirichletEpsilon);
+    for (Node* node : childNodes) {
+        node->probValue = probEpsilon * node->probValue + searchSettings->dirichletEpsilon * dirichletNoise[idx++];
+    }
 }
 
 void backup_value(Node* currentNode, float value)

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -111,18 +111,19 @@ void Node::calibrate_child_node_order()
 //        });
 //        std::sort(childNodes.begin(), childNodes.begin()+int(nodeIdxUpdate), q_plus_u_comparision);
 //    }
-    partial_sort(childNodes.begin(), childNodes.begin()+1, childNodes.end(), q_plus_u_comparision);
+    // sorts until the first n elements are correct
+    partial_sort(childNodes.begin(), childNodes.begin()+nodeIdxUpdate, childNodes.end(), q_plus_u_comparision);
 
     // sorting
     areChildNodesSorted = true;
     isCalibrated = true;
 
     // DEBUG
-//    if (!is_ordering_correct(childNodes)) {
-//        cout << "nodeIdxUpdate: " << nodeIdxUpdate << endl;
-//        print_node_statistics(this);
+    if (!is_ordering_correct(childNodes)) {
+        cout << "nodeIdxUpdate: " << nodeIdxUpdate << endl;
+        print_node_statistics(this);
         assert(is_ordering_correct(childNodes));
-//    }
+    }
 //    nodeIdxUpdate = 1;
 //    nodeIdxUpdate = 0;
 }
@@ -662,8 +663,8 @@ void print_node_statistics(Node* node)
 
 bool is_ordering_correct(vector<Node*> &childNodes)
 {
-    for (size_t i = 0; i < childNodes.size(); ++i) {
-        if (childNodes[0]->get_q_plus_u() < childNodes[i]->get_q_plus_u()) {
+    for (size_t i = 0; i < childNodes.size()-1; ++i) {
+        if (childNodes[i]->get_q_plus_u() < childNodes[i+1]->get_q_plus_u()) {
             return false;
         }
     }

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -62,9 +62,7 @@ Node::~Node()
 void Node::operator=(const Node& b)
 {
     value = b.value;
-    // deep copy of position and stateInfo -> probably change this
-    pos = new Board(*b.pos);
-    pos->setStateInfo(new StateInfo(*(b.pos->getStateInfo())));
+    // the position has already been expanded, no copy is required
     numberChildNodes = b.numberChildNodes;
     // copy the probability values for all child nodes
     for (Node* node : b.childNodes) {

--- a/src/node.h
+++ b/src/node.h
@@ -176,6 +176,14 @@ public:
     void unlock();
 
     void mark_as_uncalibrated();
+
+    /**
+     * @brief apply_dirichlet_noise_to_prior_policy Applies dirichlet noise of strength searchSettings->dirichletEpsilon with
+     * alpha value searchSettings->dirichletAlpha to the prior policy of the root node. This encourages exploration of nodes with initially low
+     * low activations.
+     */
+    void apply_dirichlet_noise_to_prior_policy();
+
 };
 
 // generate the legal moves and save them in the list

--- a/src/node.h
+++ b/src/node.h
@@ -155,7 +155,7 @@ public:
     void update_u_parent_factor();
 
     double get_current_u_value() const;
-    double get_score_value() const;
+    double get_q_plus_u() const;
     double get_u_parent_factor() const;
     float get_u_divisor_summand() const;
 
@@ -167,10 +167,7 @@ public:
     void lock();
     void unlock();
 
-    /**
-     * @brief print_node_statistics Prints all node statistics of the child nodes to stdout
-     */
-    void print_node_statistics();
+    void mark_as_uncalibrated();
 };
 
 // generate the legal moves and save them in the list
@@ -233,8 +230,6 @@ Node* select_child_node(Node* node);
  */
 extern std::ostream& operator<<(std::ostream& os, Node* node);
 
-extern bool operator< (const Node& n1, const Node& n2);
-
 /**
  * @brief delete_subtree Deletes the node itself and its pointer in the hashtable as well as all existing nodes in its subtree.
  * @param node Node of the subtree to delete
@@ -283,5 +278,21 @@ double get_current_cput(float numberVisits, float cpuctBase, float cpuctInit);
  * @return float
  */
 float get_current_u_divisor(float numberVisits, float uMin, float uInit, float uBase);
+
+/**
+ * @brief print_node_statistics Prints all node statistics of the child nodes to stdout
+ */
+void print_node_statistics(Node* node);
+
+/**
+ * @brief is_ordering_correct Validates if the ordering of the child nodes is still valid
+ * @param childNodes List of nodes, assumed to be ordered based on q+u
+ * @return boolean
+ */
+bool is_ordering_correct(vector<Node*>& childNodes);
+
+bool prob_value_comparision(const Node* n1, const Node* n2);
+
+bool q_plus_u_comparision(const Node* n1, const Node* n2);
 
 #endif // NODE_H

--- a/src/node.h
+++ b/src/node.h
@@ -82,14 +82,28 @@ private:
     inline void check_for_terminal();
 
 public:
-    Node(Node* parentNode, Move move, SearchSettings* searchSettings);
     /**
-     * @brief Node Constructor used for creating a new root node
+     * @brief Node Primary constructor which is used when expanding a node during search
      * @param parentNode Pointer to parent node
      * @param move Move which led to current board state
+     * @param searchSettings Pointer to the searchSettings
+     */
+    Node(Node* parentNode, Move move, SearchSettings* searchSettings);
+
+    /**
+     * @brief Node Constructor used for creating a root node when it wasn't found in the search tree.
+     * The position is only assigned by reference.
      * @param pos Current board position
+     * @param parentNode Pointer to parent node
+     * @param move Move which led to current board state
+     * @param searchSettings Pointer to the searchSettings
      */
     Node(Board *pos, Node *parentNode, Move move, SearchSettings* searchSettings);
+
+    /**
+     * @brief ~Node Destructor which frees memory and the board position
+     */
+    ~Node();
 
     /**
      * @brief operator= Assignment which copies the value evaluation and prior policy of the child nodes.
@@ -281,7 +295,7 @@ void get_mcts_policy(const Node *node, const float qValueWeight, const float qTh
  */
 float get_current_q_thresh(const SearchSettings* searchSettings, int numberVisits);
 
-double updated_value(const Node* node);
+double updated_value(const Node* node, DynamicVector<float>& mctsPolicy);
 
 /**
  * @brief get_current_cput Calculates the current cpuct value factor for this node based on the total node visits

--- a/src/node.h
+++ b/src/node.h
@@ -55,8 +55,8 @@ private:
     Move move;
     float value;
     float probValue;
-    double qValue;
-    double actionValue;
+    float qValue;
+    float actionValue;
     float visits;
     int virtualLossCounter;
 
@@ -71,7 +71,7 @@ private:
     bool isCalibrated;           // determines if the nodes are ordered
     bool areChildNodesSorted;
 
-    double uParentFactor;        // stores all parts of the u-value as there a observable by the parent node
+    float uParentFactor;        // stores all parts of the u-value as there a observable by the parent node
     float uDivisorSummand;       // summand which is added to the divisor of the u-divisor
 
     // if checkmateNode is != nullptr it will always be preferred over all other nodes
@@ -157,7 +157,7 @@ public:
 
     float get_visits() const;
     float get_prob_value() const;
-    double get_q_value() const;
+    float get_q_value() const;
 
     void update_q_value();
 
@@ -177,9 +177,9 @@ public:
 
     void update_u_parent_factor();
 
-    double get_current_u_value() const;
-    double get_q_plus_u() const;
-    double get_u_parent_factor() const;
+    float get_current_u_value() const;
+    float get_q_plus_u() const;
+    float get_u_parent_factor() const;
     float get_u_divisor_summand() const;
 
     void validate_candidate_node();
@@ -199,6 +199,7 @@ public:
      */
     void apply_dirichlet_noise_to_prior_policy();
 
+    float get_action_value() const;
 };
 
 // generate the legal moves and save them in the list
@@ -332,5 +333,7 @@ bool q_plus_u_comparision(const Node* n1, const Node* n2);
  * @param pv Vector in which moves will be pushed.
  */
 void get_principal_variation(const Node* rootNode, const SearchSettings* searchSettings, vector<Move>& pv);
+
+int estimate_visits_to_switch(const float secondScore, const float cpuct, Node* n);
 
 #endif // NODE_H

--- a/src/node.h
+++ b/src/node.h
@@ -60,16 +60,17 @@ private:
     float visits;
     int virtualLossCounter;
 
-    bool isTerminal;
     size_t numberChildNodes;
-    size_t nodeIdxUpdate;
+    size_t numberExpandedNodes;
 
     vector<Node*> childNodes;
 
+    bool isTerminal;
     bool isExpanded;
     bool hasNNResults;
     bool isCalibrated;           // determines if the nodes are ordered
     bool areChildNodesSorted;
+    bool isFullyExpanded;        // is true if every child node has at least 1 visit
 
     float uParentFactor;        // stores all parts of the u-value as there a observable by the parent node
     float uDivisorSummand;       // summand which is added to the divisor of the u-divisor
@@ -129,6 +130,7 @@ public:
     void revert_virtual_loss_and_update(float value);
     Node* get_parent_node() const;
     void increment_visits();
+    void increment_no_visit_idx();
     bool is_expanded() const;
     bool are_child_nodes_sorted() const;
     bool is_calibrated() const;
@@ -177,14 +179,11 @@ public:
 
     void update_u_parent_factor();
 
-    float get_current_u_value() const;
-    float get_q_plus_u() const;
+    float compute_current_u_value() const;
+    float compute_q_plus_u() const;
+
     float get_u_parent_factor() const;
     float get_u_divisor_summand() const;
-
-    void validate_candidate_node();
-    void swap_candidate_node_with_alternative();
-    void readjust_candidate_node_position();
 
     void create_child_nodes();
     void lock();
@@ -201,8 +200,6 @@ public:
 
     float get_action_value() const;
 };
-
-// generate the legal moves and save them in the list
 
 /**
  * @brief backup_value Iteratively backpropagates a value prediction across all of the parents for this node.

--- a/src/node.h
+++ b/src/node.h
@@ -71,7 +71,7 @@ private:
     bool isCalibrated;           // determines if the nodes are ordered
     bool areChildNodesSorted;
 
-    double uParentFactor;         // stores all parts of the u-value as there a observable by the parent node
+    double uParentFactor;        // stores all parts of the u-value as there a observable by the parent node
     float uDivisorSummand;       // summand which is added to the divisor of the u-divisor
 
     // if checkmateNode is != nullptr it will always be preferred over all other nodes
@@ -143,6 +143,7 @@ public:
      * @brief sort_nodes_by_probabilities Sorts all child nodes in ascending order based on their probability value
      */
     void sort_child_nodes_by_probabilities();
+    void sort_child_nodes_by_q_plus_u();
 
     /**
      * @brief calibrate_child_node_order Applies a partial sort for the previously updated nodes depending on nodeIdxUpdate

--- a/src/node.h
+++ b/src/node.h
@@ -279,7 +279,7 @@ void get_mcts_policy(const Node *node, const float qValueWeight, const float qTh
  * for the final move selection after the search
  * @return float
  */
-float get_current_q_thresh(SearchSettings* searchSettings, int numberVisits);
+float get_current_q_thresh(const SearchSettings* searchSettings, int numberVisits);
 
 double updated_value(const Node* node);
 
@@ -310,5 +310,12 @@ bool is_ordering_correct(vector<Node*>& childNodes);
 bool prob_value_comparision(const Node* n1, const Node* n2);
 
 bool q_plus_u_comparision(const Node* n1, const Node* n2);
+
+/**
+ * @brief get_principal_variation Traverses the tree using the get_mcts_policy() function until a leaf or terminal node is found.
+ * The moves a are pushed into the pv vector.
+ * @param pv Vector in which moves will be pushed.
+ */
+void get_principal_variation(const Node* rootNode, const SearchSettings* searchSettings, vector<Move>& pv);
 
 #endif // NODE_H

--- a/src/node.h
+++ b/src/node.h
@@ -91,6 +91,14 @@ public:
      */
     Node(Board *pos, Node *parentNode, Move move, SearchSettings* searchSettings);
 
+    /**
+     * @brief operator= Assignment which copies the value evaluation and prior policy of the child nodes.
+     * The qValues, actionValues and visits of the child nodes aren't copied over.
+     * This operator is used during a transposition event.
+     * @param b Node from which the stats will be copied
+     */
+    void operator=(const Node& b);
+
     void expand();
     Move get_move() const;
     vector<Node*> get_child_nodes() const;

--- a/src/node.h
+++ b/src/node.h
@@ -19,7 +19,7 @@
 
 /*
  * @file: node.h
- * Created on 13.05.2019
+ * Created on 28.08.2019
  * @author: queensgambit
  *
  * Class which stores the statistics of all nodes and in the search tree.
@@ -28,282 +28,166 @@
 #ifndef NODE_H
 #define NODE_H
 
+#include <iostream>
 #include <mutex>
+#include <unordered_map>
+
+#include <blaze/Math.h>
+
 #include "position.h"
 #include "movegen.h"
 #include "board.h"
 
-#include <blaze/Math.h>
+#include "agents/config/searchsettings.h"
 
 using blaze::HybridVector;
 using blaze::DynamicVector;
-#include <unordered_map>
 using namespace std;
-#include <iostream>
-#include "agents/config/searchsettings.h"
 
 class Node
 {
 private:
-    std::mutex mtx;
-    float value;
+    mutex mtx;
     Board* pos;
-    DynamicVector<float> policyProbSmall;
-    DynamicVector<float> childNumberVisits;
-    DynamicVector<float> actionValues;
-    DynamicVector<float> qValues;
+    Node* parentNode;
 
     // singular values
-    double probValue;
+    Move move;
+    float value;
+    float probValue;
     double qValue;
     double actionValue;
-    double visits;
-    Move move;
+    unsigned int visits;
+    int virtualLossCounter;
 
-    std::vector<Move> legalMoves;
     bool isTerminal;
-    unsigned int nbDirectChildNodes;
+    size_t numberChildNodes;
 
-    float initialValue;
-    int numberVisits = 0;
-    std::vector<Node*> childNodes;
+    vector<Node*> childNodes;
 
-    Node* canidateNode;
-    Node* secondCandidateNode;
-    Node* parentNode;
-    unsigned int childIdxForParent;
+    bool isExpanded;
     bool hasNNResults;
+    bool isCalibrated;  // determines if the nodes are ordered
+    bool areChildNodesSorted;
 
-    // if checkMateIdx is != -1 it will always be preferred over all other nodes
-    int checkmateIdx;
+    // if checkmateNode is != nullptr it will always be preferred over all other nodes
+    Node* checkmateNode;
 
     SearchSettings* searchSettings;
 
-    /**
-     * @brief check_for_terminal Checks if the currect node is a terminal node and updates the checkmateIdx for its parent in case of a checkmate terminal
-     */
     inline void check_for_terminal();
 
-    /**
-     * @brief get_current_cput Calculates the current cpuct value factor for this node based on the total node visits
-     * @return float
-     */
-    inline float get_current_cput();
-
-    /**
-     * @brief get_current_u_divisor Calculates the current u-initialization-divisor factor for this node based on the total node visits
-     * @return float
-     */
-    inline float get_current_u_divisor();
-
-    /**
-     * @brief get_current_q_thresh Calculates the current q-thresh factor which is used to disable the effect of the q-value for low visited nodes
-     * for the final move selection after the search
-     * @return float
-     */
-    inline float get_current_q_thresh();
-
-    /**
-     * @brief get_current_u_values Calucates and returns the current u-values for this node
-     * @return DynamicVector<float>
-     */
-    DynamicVector<float> get_current_u_values();
-
-    /**
-     * @brief get_current_u_values Calucates anCalucates and returns the current u-values for this node
-     * @return DynamicVector<float>
-     */
-    inline double get_current_u_value() const;
-
-    /**
-      * @brief enhance_checks Enhances all possible checking moves below threshCheck by incrementCheck and returns true if a modification
-      * was applied. This signals that a renormizalition should be applied afterwards.
-      * @param increment_check Constant factor which is added to the checks below threshCheck
-      * @param threshCheck Probability threshold for checking moves
-      * @return bool
-      */
-     inline bool enhance_checks(const float incrementCheck, float threshCheck);
-
-     /**
-       * @brief enhance_captures Enhances all possible capture moves below threshCapture by incrementCapture and returns true if a modification
-       * was applied. This signals that a renormizalition should be applied afterwards.
-       * @param incrementCapture Constant factor which is added to the checks below threshCheck
-       * @param threshCapture Probability threshold for capture moves
-       * @return bool
-       */
-     inline bool enhance_captures(const float incrementCapture, float threshCapture);
-
 public:
+    Node(Node* parentNode, Move move);
+    /**
+     * @brief Node Constructor used for creating a new root node
+     * @param parentNode Pointer to parent node
+     * @param move Move which led to current board state
+     * @param pos Current board position
+     */
+    Node(Board *pos, Node *parentNode, Move move);
 
-    Node(Board *pos,
-         Node *parentNode,
-         unsigned int childIdxForParent,
-         SearchSettings* searchSettings);
+    void expand();
+    Move get_move() const;
+    vector<Node*> get_child_nodes() const;
+    bool is_terminal() const;
+    bool has_nn_results() const;
+    Color side_to_move() const;
+    Board* get_pos() const;
+    void set_prob_value(float value);
+    float get_value() const;
+
+    void set_nn_results(float nn_value, const DynamicVector<float>& policyProbSmall);
+    void apply_virtual_loss();
+    void revert_virtual_loss();
+    void revert_virtual_loss_and_update(float value);
+    Node* get_parent_node() const;
+    void increment_visits();
+    bool is_expanded() const;
+    bool are_child_nodes_sorted() const;
+    bool is_calibrated() const;
+    Node* first_child_node() const;
+    Node* second_child_node() const;
+    Key hash_key() const;
+
+    size_t get_number_child_nodes() const;
+    Node* get_checkmate_node() const;
 
     /**
-     * @brief Node Copy constructor which copies the value evaluation, board position, prior policy and checkmateIdx.
-     * The qValues, actionValues and visits aren't copied over.
-     * @param b Node from which the stats will be copied
+     * @brief sort_nodes_by_probabilities Sorts all child nodes in ascending order based on their probability value
      */
-    Node(const Node& b);
-    ~Node();
-
-    DynamicVector<float> getPVecSmall() const;
-    void setPVecSmall(const DynamicVector<float> &value);
-    std::vector<Move> getLegalMoves() const;
-    void setLegalMoves(const std::vector<Move> &value);
-    void apply_virtual_loss_to_child(unsigned int childIdx);
-    float getValue() const;
-    void setValue(float value);
-    size_t select_child_node();
-    Node* select_node();
-
-    /**
-     * @brief get_child_node Returns the child node at the given index.
-     * A nullptr is returned if the child node wasn't expanded yet and no check is done if the childIdx is smaller than
-     * @param childIdx Index for the next child node to select
-     * @return child node
-     */
-    Node* get_child_node(size_t childIdx);
-
-    /**
-     * @brief backup_value Iteratively backpropagates a value prediction across all of the parents for this node.
-     * The value is flipped at every ply.
-     * @param value Value evaluation to backup, this is the NN eval in the general case or can be from a terminal node
-     */
-    void backup_value(unsigned int childIdx, float value);
-
-    /**
-     * @brief revert_virtual_loss_and_update Revert the virtual loss effect and apply the backpropagated value of its child node
-     * @param child_idx Index to the child node to update
-     * @param value Specifies the value evaluation to backpropagate
-     */
-    void revert_virtual_loss_and_update(unsigned int child_idx, float value);
-
-    /**
-     * @brief backup_collision Iteratively removes the virtual loss of the collision event that occured
-     * @param childIdx Index to the child node to update
-     */
-    void backup_collision(unsigned int childIdx);
-
-    /**
-     * @brief revert_virtual_loss Reverts the virtual loss for a target node
-     * @param child_idx Index to the child node to update
-     */
-    void revert_virtual_loss(unsigned int childIdx);
+    void sort_child_nodes_by_probabilities();
 
     /**
      * @brief make_to_root Makes the node to the current root node by setting its parent to a nullptr
      */
     void make_to_root();
 
-    /**
-      * @brief enhance_moves Calls enhance_checks & enchance captures if the searchSetting suggests it and applies a renormilization afterwards
-      * @param threshCheck Threshold probability for checking moves
-      * @param checkFactor Factor based on the maximum probability with which checks will be increased
-      * @param threshCapture Threshold probability for capture moves
-      * @param captureFactor Factor based on the maximum probability with which captures will be increased
-      */
-    void enhance_moves(const float threshCheck = 0.1f, const float checkFactor=0.5f, const float threshCapture = 0.1f, const float captureFactor=0.05f);
-
-    friend class SearchThread;
-    friend class MCTSAgent;
-    friend bool operator> (const Node& n1, const Node& n2);
-//    friend bool operator<= (const Node& n1, const Node& n2);
-
-//    friend bool operator< (const Node& n1, const Node& n2);
-//    friend bool operator>= (const Node& n1, const Node& n2);
-    inline double get_score_value() const;
-
-    DynamicVector<float> getPolicyProbSmall();
-    void setPolicyProbSmall(const DynamicVector<float> &value);
+    unsigned int get_visits() const;
+    float get_prob_value() const;
+    double get_q_value() const;
 
     /**
-     * @brief get_mcts_policy Returns the final policy after the mcts search which is used for move selection, in most cases argmax(mctsPolicy).
-     * Depending on the searchSettings, Q-values will be taken into account for creating this.
-     * @param mctsPolicy Output of the final mcts policy after search
+     * @brief init_board Initializes the board position given the previous position and move to play
+     * @param parentPos Previous board position
+     * @param move Move to apply
+     * @param pos New position which will be set
      */
-    void get_mcts_policy(DynamicVector<float>& mctsPolicy);
-    DynamicVector<float> getQValues() const;
-
-    /**
-     * @brief apply_dirichlet_noise_to_prior_policy Applies dirichlet noise of strength searchSettings->dirichletEpsilon with
-     * alpha value searchSettings->dirichletAlpha to the prior policy of the root node. This encourages exploration of nodes with initially low
-     * low activations.
-     */
-    void apply_dirichlet_noise_to_prior_policy();
-
-    void setQValues(const DynamicVector<float> &value);
-    DynamicVector<float> getChildNumberVisits() const;
-    unsigned int getNbDirectChildNodes() const;
-    Board* getPos();
-
-    /**
-     * @brief delete_subtree Deletes the node itself and all existing nodes in its subtree.
-     * @param node ode of the subtree to delete
-     */
-    static void delete_subtree(Node *node);
-
-    /**
-     * @brief delete_subtree Deletes the node itself and its pointer in the hashtable as well as all existing nodes in its subtree.
-     * @param node Node of the subtree to delete
-     * @param hashTable Pointer to the hashTable which stores a pointer to all active nodes
-     */
-    static void delete_subtree_and_hash_entries(Node *node, unordered_map<Key, Node*>* hashTable);
-
-
-    /**
-     * @brief delete_sibling_subtrees Deletes all subtrees from all simbling nodes, deletes their hash table entry and sets the visit access to nullptr
-     * @param hashTable Pointer to the hashTables
-     */
-    void delete_sibling_subtrees(unordered_map<Key, Node*>* hashTable);
-
-    int getNumberVisits() const;
-
-    /**
-     * @brief get_principal_variation Traverses the tree using the get_mcts_policy() function until a leaf or terminal node is found.
-     * The moves a are pushed into the pv vector.
-     * @param pv Vector in which moves will be pushed.
-     */
-    void get_principal_variation(std::vector<Move>& pv);
-
-    /**
-     * @brief hash_key Returns the hash key of its corresponding position
-     * @return
-     */
-    Key hash_key();
-    static void setSearchSettings(SearchSettings *value);
-
-    /**
-     * @brief find_move_idx Returns the index of the required move in its move list.
-     * -1 is returned if the move wasn't found.
-     * @param m Move that is searched for
-     * @return Respective child index for the given move in its move list
-     */
-    int find_move_idx(Move m);
-
-    /**
-     * @brief sort_nodes_by_probabilities Sorts all child nodes in ascending order based on their probability value
-     */
-    void sort_nodes_by_probabilities();
-
-    void assign_values_to_child_nodes();
-
-    std::vector<Node *> getChildNodes() const;
-    double getProbValue() const;
-    double getQValue() const;
-    double getActionValue() const;
-    double getVisits() const;
-    Move getMove() const;
-
-    /**
-     * @brief print_node_statistics Prints all node statistics of the child nodes to stdout
-     */
-    void print_node_statistics();
-
-    void fill_child_node_moves();
+    void init_board();
 
 };
+
+// generate the legal moves and save them in the list
+
+/**
+ * @brief backup_value Iteratively backpropagates a value prediction across all of the parents for this node.
+ * The value is flipped at every ply.
+ * @param value Value evaluation to backup, this is the NN eval in the general case or can be from a terminal node
+ */
+void backup_value(Node* currentNode, float value);
+
+void backup_collision(Node* currentNode);
+
+/**
+ * @brief retrieve_legal_moves Retrieves each move from the child nodes
+ * @param childNodes List of child nodes
+ * @return Legal move list
+ */
+vector<Move> retrieve_legal_moves(const vector<Node*>& childNodes);
+
+/**
+ * @brief create_child_nodes Generates a new child node for every legal move
+ * @param parentNode Parent node to which all child nodes will be connected with
+ * @param pos Board position
+ * @param childNodes Empty vector which will be filled for every legal move
+ */
+inline void create_child_nodes(Node* parentNode, const Board* pos, vector<Node*> &childNodes);
+
+// https://stackoverflow.com/questions/6339970/c-using-function-as-parameter
+typedef bool (* vFunctionMoveType)(const Board* pos, Move move);
+inline bool isCheck(const Board* pos, Move move);
+inline bool isCapture(const Board* pos, Move move);
+
+/**
+ * @brief enhance_checks Enhances all possible checking moves below threshCheck by incrementCheck and returns true if a modification
+ * was applied. This signals that a renormizalition should be applied afterwards.
+ * @param increment_check Constant factor which is added to the checks below threshCheck
+ * @param threshCheck Probability threshold for checking moves
+ * @return bool
+*/
+inline bool enhance_move_type(float increment, float thresh, const Board* pos, const vector<Move>& legalMoves,
+                              vFunctionMoveType func, DynamicVector<float>& policyProbSmall);
+
+/**
+  * @brief enhance_moves Calls enhance_checks & enchance captures if the searchSetting suggests it and applies a renormilization afterwards
+  * @param threshCheck Threshold probability for checking moves
+  * @param checkFactor Factor based on the maximum probability with which checks will be increased
+  * @param threshCapture Threshold probability for capture moves
+  * @param captureFactor Factor based on the maximum probability with which captures will be increased
+  */
+void enhance_moves(const SearchSettings* searchSettings, const Board* pos, const vector<Move>& legalMoves, DynamicVector<float>& policyProbSmall);
+
+Node* select_child_node(Node* node);
 
 /**
  * @brief operator << Overload of stdout operator. Prints move, number visits, probability Value and Q-value
@@ -312,5 +196,47 @@ public:
  * @return ostream
  */
 extern std::ostream& operator<<(std::ostream& os, Node* node);
+
+/**
+ * @brief print_node_statistics Prints all node statistics of the child nodes to stdout
+ */
+void print_node_statistics(Node* node);
+
+/**
+ * @brief delete_subtree Deletes the node itself and its pointer in the hashtable as well as all existing nodes in its subtree.
+ * @param node Node of the subtree to delete
+ * @param hashTable Pointer to the hashTable which stores a pointer to all active nodes
+ */
+void delete_subtree_and_hash_entries(Node *node, unordered_map<Key, Node*>* hashTable);
+
+/**
+ * @brief delete_sibling_subtrees Deletes all subtrees from all simbling nodes, deletes their hash table entry and sets the visit access to nullptr
+ * @param hashTable Pointer to the hashTables
+ */
+void delete_sibling_subtrees(Node* node, unordered_map<Key, Node*>* hashTable);
+
+float get_visits(Node* node);
+float get_q_value(Node* node);
+typedef float (* vFunctionValue)(Node* node);
+DynamicVector<float> retrieve_dynamic_vector(const vector<Node*>& childNodes, vFunctionValue func);
+
+DynamicVector<float> retrieve_visits(const Node* node);
+DynamicVector<float> retrieve_q_values(const Node* node);
+
+/**
+ * @brief get_mcts_policy Returns the final policy after the mcts search which is used for move selection, in most cases argmax(mctsPolicy).
+ * Depending on the searchSettings, Q-values will be taken into account for creating this.
+ * @param mctsPolicy Output of the final mcts policy after search
+ */
+void get_mcts_policy(const Node *node, const float qValueWeight, const float qThresh, DynamicVector<float> &mctsPolicy);
+
+/**
+ * @brief get_current_q_thresh Calculates the current q-thresh factor which is used to disable the effect of the q-value for low visited nodes
+ * for the final move selection after the search
+ * @return float
+ */
+float get_current_q_thresh(SearchSettings* searchSettings, int numberVisits);
+
+double updated_value(const Node* node);
 
 #endif // NODE_H

--- a/src/node.h
+++ b/src/node.h
@@ -162,6 +162,15 @@ public:
     void validate_candidate_node();
     void swap_candidate_node_with_alternative();
     void readjust_candidate_node_position();
+
+    void create_child_nodes();
+    void lock();
+    void unlock();
+
+    /**
+     * @brief print_node_statistics Prints all node statistics of the child nodes to stdout
+     */
+    void print_node_statistics();
 };
 
 // generate the legal moves and save them in the list
@@ -225,11 +234,6 @@ Node* select_child_node(Node* node);
 extern std::ostream& operator<<(std::ostream& os, Node* node);
 
 extern bool operator< (const Node& n1, const Node& n2);
-
-/**
- * @brief print_node_statistics Prints all node statistics of the child nodes to stdout
- */
-void print_node_statistics(Node* node);
 
 /**
  * @brief delete_subtree Deletes the node itself and its pointer in the hashtable as well as all existing nodes in its subtree.

--- a/src/optionsuci.cpp
+++ b/src/optionsuci.cpp
@@ -35,8 +35,8 @@ void OptionsUCI::init(OptionsMap &o)
 {
     o["UCI_Variant"]              << Option(availableVariants.front().c_str(), availableVariants);
     o["Search_Type"]              << Option("mcts", {"mcts"});
-    o["Context"]                  << Option("gpu", {"cpu", "gpu"});
-    o["Batch_Size"]               << Option(8, 1, 8192); // 8
+    o["Context"]                  << Option("cpu", {"cpu", "gpu"});
+    o["Batch_Size"]               << Option(8, 1, 8192);
     o["Threads"]                  << Option(1, 1, 512);
     o["Centi_CPuct_Init"]         << Option(250, 1, 99999);
     o["CPuct_Base"]               << Option(19652, 1, 99999);
@@ -53,7 +53,7 @@ void OptionsUCI::init(OptionsMap &o)
     o["Max_Search_Depth"]         << Option(99, 1, 99999);
     o["Centi_Temperature"]        << Option(0, 0, 99999);
     o["Temperature_Moves"]        << Option(0, 0, 99999);
-    o["Virtual_Loss"]             << Option(3, 0, 99999); // 3
+    o["Virtual_Loss"]             << Option(3, 0, 99999);
     o["Nodes"]                    << Option(0, 0, 99999);
     o["Use_Raw_Network"]          << Option(false);
     o["Enhance_Checks"]           << Option(true);

--- a/src/optionsuci.cpp
+++ b/src/optionsuci.cpp
@@ -35,8 +35,8 @@ void OptionsUCI::init(OptionsMap &o)
 {
     o["UCI_Variant"]              << Option(availableVariants.front().c_str(), availableVariants);
     o["Search_Type"]              << Option("mcts", {"mcts"});
-    o["Context"]                  << Option("cpu", {"cpu", "gpu"});
-    o["Batch_Size"]               << Option(8, 1, 8192);
+    o["Context"]                  << Option("gpu", {"cpu", "gpu"});
+    o["Batch_Size"]               << Option(8, 1, 8192); // 8
     o["Threads"]                  << Option(1, 1, 512);
     o["Centi_CPuct_Init"]         << Option(250, 1, 99999);
     o["CPuct_Base"]               << Option(19652, 1, 99999);
@@ -53,7 +53,7 @@ void OptionsUCI::init(OptionsMap &o)
     o["Max_Search_Depth"]         << Option(99, 1, 99999);
     o["Centi_Temperature"]        << Option(0, 0, 99999);
     o["Temperature_Moves"]        << Option(0, 0, 99999);
-    o["Virtual_Loss"]             << Option(3, 0, 99999);
+    o["Virtual_Loss"]             << Option(3, 0, 99999); // 3
     o["Nodes"]                    << Option(0, 0, 99999);
     o["Use_Raw_Network"]          << Option(false);
     o["Enhance_Checks"]           << Option(true);

--- a/src/optionsuci.cpp
+++ b/src/optionsuci.cpp
@@ -35,10 +35,10 @@ void OptionsUCI::init(OptionsMap &o)
 {
     o["UCI_Variant"]              << Option(availableVariants.front().c_str(), availableVariants);
     o["Search_Type"]              << Option("mcts", {"mcts"});
-    o["Context"]                  << Option("cpu", {"cpu", "gpu"});
+    o["Context"]                  << Option("gpu", {"cpu", "gpu"});
     o["Batch_Size"]               << Option(8, 1, 8192);
-    o["Threads"]                  << Option(1, 1, 512);
-    o["Centi_CPuct_Init"]         << Option(250, 1, 99999);
+    o["Threads"]                  << Option(2, 1, 512);
+    o["Centi_CPuct_Init"]         << Option(1024, 1, 99999);
     o["CPuct_Base"]               << Option(19652, 1, 99999);
     o["Centi_Dirichlet_Epsilon"]  << Option(25, 1, 99999);
     o["Centi_Dirichlet_Alpha"]    << Option(20, 1, 99999);
@@ -58,11 +58,13 @@ void OptionsUCI::init(OptionsMap &o)
     o["Use_Raw_Network"]          << Option(false);
     o["Enhance_Checks"]           << Option(true);
     o["Enhance_Captures"]         << Option(false);
-    o["Use_Transposition_Table"]  << Option(true);
+    o["Use_Transposition_Table"]  << Option(false);
     o["Model_Directory"]          << Option("model/");
     o["Move_Overhead"]            << Option(50, 0, 5000);
     o["Centi_Random_Move_Factor"] << Option(0, 0, 99);
 }
+
+//r5nr/pkpP1ppp/4p3/3rN3/1b2b3/2PNB3/P1K2PPP/1N5R/QQpbppp b - - 0 22
 
 
 void OptionsUCI::setoption(istringstream &is)

--- a/src/optionsuci.cpp
+++ b/src/optionsuci.cpp
@@ -58,7 +58,7 @@ void OptionsUCI::init(OptionsMap &o)
     o["Use_Raw_Network"]          << Option(false);
     o["Enhance_Checks"]           << Option(true);
     o["Enhance_Captures"]         << Option(false);
-    o["Use_Transposition_Table"]  << Option(false);
+    o["Use_Transposition_Table"]  << Option(true);
     o["Model_Directory"]          << Option("model/");
     o["Move_Overhead"]            << Option(50, 0, 5000);
     o["Centi_Random_Move_Factor"] << Option(0, 0, 99);

--- a/src/searchthread.cpp
+++ b/src/searchthread.cpp
@@ -252,6 +252,9 @@ void fill_nn_results(size_t batchIdx, bool is_policy_map, const SearchSettings* 
                        legalMoves,
                        get_current_move_lookup(node->side_to_move()),
                        policyProbSmall);
+    if (!is_policy_map) {
+        apply_softmax(policyProbSmall);
+    }
     enhance_moves(searchSettings, node->get_pos(), legalMoves, policyProbSmall);
     node->set_nn_results(valueOutputs->At(batchIdx, 0), policyProbSmall);
 }

--- a/src/searchthread.cpp
+++ b/src/searchthread.cpp
@@ -95,6 +95,9 @@ Node* get_new_child_to_evaluate(Node* rootNode, bool useTranspositionTable, unor
         currentNode = select_child_node(currentNode);
         currentNode->apply_virtual_loss();
         description.depth++;
+//        if (description.depth == 2 && currentNode->is_expanded() && currentNode->get_pos()->fen() == "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR[] b KQkq - 0 1") {
+//            cout << "move " << UCI::move(currentNode->get_move(), false) << endl;
+//        }
 //        cout << "string info depth " << description.depth << endl;
         currentNode->lock();
         if (!currentNode->is_expanded()) {

--- a/src/searchthread.cpp
+++ b/src/searchthread.cpp
@@ -82,10 +82,11 @@ SearchLimits *SearchThread::get_search_limits() const
 inline Node* get_new_child_to_evaluate(Node* rootNode, bool &isCollision, bool &isTerminal, size_t &depth)
 {
     Node *currentNode = rootNode;
+    rootNode->apply_virtual_loss();
     depth = 0;
     while (true) {
-        currentNode->apply_virtual_loss();
         currentNode = select_child_node(currentNode);
+        currentNode->apply_virtual_loss();
         depth++;
         if (!currentNode->is_expanded()) {
             currentNode->init_board();
@@ -209,6 +210,7 @@ void SearchThread::thread_iteration()
         netBatch->predict(inputPlanes, *valueOutputs, *probOutputs);
         set_nn_results_to_child_nodes();
     }
+//    cout << "backup values" << endl;
     backup_value_outputs();
     backup_collisions();
 //    rootNode->numberVisits = sum(rootNode->childNumberVisits);
@@ -220,7 +222,6 @@ void go(SearchThread *t)
 
     do {
         t->thread_iteration();
-        break;
     } while(t->get_is_running() && t->nodes_limits_ok());
 }
 

--- a/src/searchthread.cpp
+++ b/src/searchthread.cpp
@@ -233,7 +233,7 @@ void go(SearchThread *t)
 void backup_values(vector<Node*>& nodes)
 {
     for (auto node: nodes) {
-        backup_value(node, node->get_value());
+        backup_value(node, -node->get_value());
     }
     nodes.clear();
 }

--- a/src/searchthread.cpp
+++ b/src/searchthread.cpp
@@ -95,6 +95,7 @@ Node* get_new_child_to_evaluate(Node* rootNode, bool useTranspositionTable, unor
         currentNode = select_child_node(currentNode);
         currentNode->apply_virtual_loss();
         description.depth++;
+//        cout << "string info depth " << description.depth << endl;
         currentNode->lock();
         if (!currentNode->is_expanded()) {
             currentNode->init_board();
@@ -183,8 +184,8 @@ void SearchThread::create_mini_batch()
             transpositionNodes.push_back(currentNode);
         }
         else if(description.isTerminal) {
-            //            terminalNodes.push_back(parentNode->childNodes[childIdx]);
-            backup_value(currentNode, currentNode->get_value());
+//                        terminalNodes.push_back(parentNode->childNodes[childIdx]);
+            backup_value(currentNode, -currentNode->get_value());
         }
         else if (description.isCollision) {
             // store a pointer to the collision node in order to revert the virtual loss of the forward propagation

--- a/src/searchthread.cpp
+++ b/src/searchthread.cpp
@@ -95,10 +95,7 @@ Node* get_new_child_to_evaluate(Node* rootNode, bool useTranspositionTable, unor
         currentNode = select_child_node(currentNode);
         currentNode->apply_virtual_loss();
         description.depth++;
-//        if (description.depth == 2 && currentNode->is_expanded() && currentNode->get_pos()->fen() == "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR[] b KQkq - 0 1") {
-//            cout << "move " << UCI::move(currentNode->get_move(), false) << endl;
-//        }
-//        cout << "string info depth " << description.depth << endl;
+
         currentNode->lock();
         if (!currentNode->is_expanded()) {
             currentNode->init_board();
@@ -187,7 +184,7 @@ void SearchThread::create_mini_batch()
             transpositionNodes.push_back(currentNode);
         }
         else if(description.isTerminal) {
-//                        terminalNodes.push_back(parentNode->childNodes[childIdx]);
+            //                        terminalNodes.push_back(parentNode->childNodes[childIdx]);
             backup_value(currentNode, -currentNode->get_value());
         }
         else if (description.isCollision) {

--- a/src/searchthread.cpp
+++ b/src/searchthread.cpp
@@ -199,7 +199,7 @@ void SearchThread::create_mini_batch()
 void SearchThread::thread_iteration()
 {
     create_mini_batch();
-    if (newNodes.size() > 0) {
+    if (newNodes.size() != 0) {
         netBatch->predict(inputPlanes, *valueOutputs, *probOutputs);
         set_nn_results_to_child_nodes();
     }
@@ -212,7 +212,6 @@ void SearchThread::thread_iteration()
 void go(SearchThread *t)
 {
     t->set_is_running(true);
-
     do {
         t->thread_iteration();
     } while(t->get_is_running() && t->nodes_limits_ok());

--- a/src/searchthread.h
+++ b/src/searchthread.h
@@ -74,15 +74,6 @@ private:
      */
     void backup_collisions();
 
-    /**
-     * @brief copy_node Copies the node with the NN evaluation based on a preexisting node
-     * @param it Iterator which from the hash table
-     * @param newPos Board position which belongs to the node
-     * @param parentNode Parent node of the new node
-     * @param childIdx Index on how to visit the child node from its parent
-     */
-    inline void copy_node(const unordered_map<Key,Node*>::const_iterator &it, Board* newPos, Node* parentNode, size_t childIdx);
-
 public:
     /**
      * @brief SearchThread
@@ -128,16 +119,27 @@ public:
 
 void go(SearchThread *t);
 
+struct NodeDescription
+{
+    // flag signaling a collision event, same node was selected multiple time
+    bool isCollision;
+    // flag signaling a terminal state
+    bool isTerminal;
+    // flag signaling a transposition state
+    bool isTranposition;
+    // depth which was reached on this rollout
+    size_t depth;
+};
+
 /**
  * @brief get_new_child_to_evaluate Traverses the search tree beginning from the root node and returns the prarent node and child index for the next node to expand.
- * In the case a collision event occured the isCollision flag will be set and for a terminal node the isTerminal flag is set.
- * @param childIdx Move index for the parent node in order to expand the next node
- * @param isCollision Flag signaling a collision event, same node was selected multiple time
- * @param isTerminal Flag signaling a terminal state
- * @param depth Depth which was reached on this rollout
- * @return
+ * @param rootNode Root node where all simulations start
+ * @param useTranspositionTable Flag if the transposition table shall be used
+ * @param hashTable Pointer to the hashTable
+ * @param description Output struct which holds information what type of node it is
+ * @return Pointer to next child to evaluate (can also be terminal or tranposition node in which case no NN eval is required)
  */
-inline Node* get_new_child_to_evaluate(Node* rootNode, bool &isCollision,  bool &isTerminal, size_t &depth);
+Node* get_new_child_to_evaluate(Node* rootNode, bool useTranspositionTable, unordered_map<Key, Node*>* hashTable, NodeDescription& description);
 
 void backup_values(vector<Node*>& nodes);
 
@@ -148,7 +150,7 @@ void backup_values(vector<Node*>& nodes);
  * @param childIdx Index on how to visit the child node from its parent
  * @param numberNewNodes Index of the new node in the current batch
  */
-inline void prepare_node_for_nn(Node* newNode,  size_t numberNewNodes, vector<Node*>& newNodes, float* inputPlanes);
+inline void prepare_node_for_nn(Node* newNode, vector<Node*>& newNodes, float* inputPlanes);
 
 void fill_nn_results(size_t batchIdx, bool is_policy_map, const SearchSettings* searchSettings, NDArray* valueOutputs, NDArray* probOutputs, Node *node);
 


### PR DESCRIPTION
Concept
--------
The child nodes are initially sorted based on the assigned probability values.
Next the child nodes with the top highest Q+U values are continuously set as the first two entries in the list. This is done via partial sorting which is executed on all already expanded child nodes (child nodes with a visit > 1) and the top nodes with the highest probability which haven't been expanded (visited) yet. 

## Example

A new node n (with no visits) has been expanded and the probability values have been set.
Its value evaluation is back-propagated and no sorting is being done yet.
-> isSorted = False
-> isCalibrated = False
-> numberExpandedNodes = 0

This node n is selected again in a different simulation (playout).
All child nodes sorted based on probabilities and the first node is selected for expansion.
-> isSorted = True
-> isCalibrated = True
-> numberExpandedNodes = 1

For all remaining visits the following scheme is applied:

Case: Calibration=true
Candidate node is only compared with alternative node.
If Q+U of childNode[0] is still higher than Q+U of childNode[1]
-> simulation selects candidate node and applies virtual loss counter.
else
find new candidate and alternative
-> partial sort for all actual childNodes and the first non-expanded childNodes to find the node with highest and 2nd highest Q+U:
size_t idx = min(numberChildNodes, numberExpandedNodes+2);
partial_sort(childNodes.begin(), childNode.begin()+2, childNodes.begin()+idx);

Case: Calibration=false
-> calibrate_child_node_order()

Every time a node is updated via back-propagation Calibration is set to false.

The idea of (partially) sorting nodes based on their Q+U value originates from [lc0](https://github.com/LeelaChessZero/lc0 ) and was also employed in [allie](https://github.com/manyoso/allie).

_This PR also transforms multiple functions into free functions and removes friend attribute between Node<->MCTSAgent and Node<->SearchThread._